### PR TITLE
feat: Add /dejunk sell tsm chat command

### DIFF
--- a/src/commands.lua
+++ b/src/commands.lua
@@ -44,7 +44,7 @@ function Commands.help()
   Addon:ForcePrint(L.COMMANDS .. ":")
   Addon:ForcePrint(Colors.Gold("  /dejunk"), "-", L.COMMAND_DESCRIPTION_OPTIONS)
 
-  Addon:ForcePrint(Colors.Gold("  /dejunk sell"), "-", L.COMMAND_DESCRIPTION_SELL)
+  Addon:ForcePrint(Colors.Gold("  /dejunk sell"), Colors.Grey("[tsm]"), "-", L.COMMAND_DESCRIPTION_SELL)
   Addon:ForcePrint(Colors.Gold("  /dejunk destroy"), "-", L.COMMAND_DESCRIPTION_DESTROY)
   Addon:ForcePrint(Colors.Gold("  /dejunk loot"), "-", L.COMMAND_DESCRIPTION_LOOT)
 
@@ -71,7 +71,10 @@ function Commands.junk()
 end
 
 --- Starts the `Seller`.
-function Commands.sell()
+function Commands.sell(arg)
+  if arg == "tsm" then
+    return Commands.sellTsm()
+  end
   Seller:Start()
 end
 


### PR DESCRIPTION
This commit introduces a new chat command, `/dejunk sell tsm`, which allows users to sell items based on their TSM (TradeSkillMaster) "Destroy" value.

The command leverages the existing TSM integration, which identifies items that are more profitable to sell to a vendor than to destroy for materials.

Changes:
- The `Commands.sell` function in `src/commands.lua` has been updated to accept a "tsm" argument, which triggers the TSM-based selling logic by calling `Commands.sellTsm`.
- The help text in `Commands.help` has been updated to reflect the new command option.